### PR TITLE
Correct nullability in 21.merge-two-sorted-lists.kt

### DIFF
--- a/easy/21.merge-two-sorted-lists.kt
+++ b/easy/21.merge-two-sorted-lists.kt
@@ -36,29 +36,29 @@
  */
 class Solution {
     fun mergeTwoLists(l1: ListNode?, l2: ListNode?): ListNode? {
-        var result: ListNode? = ListNode(0)
+        val result = ListNode(0)
         var current = result
-        
-        var node1 = l1
-        var node2 = l2
+
+        var node1 = list1
+        var node2 = list2
         while (node1 != null || node2 != null) {
             if (node1 == null) {
-                current?.next = node2
+                current.next = node2
                 break
             }
             if (node2 == null) {
-                current?.next = node1
+                current.next = node1
                 break
             }
 
-            if (node1?.`val` < node2?.`val`) {
-                current?.next = node1
-                node1 = node1?.next
+            if (node1.`val` < node2.`val`) {
+                current.next = node1
+                node1 = node1.next
             } else {
-                current?.next = node2
-                node2 = node2?.next
+                current.next = node2
+                node2 = node2.next
             }
-            current = current?.next
+            current = current.next!!/*compiler can't yet determine nullability of/smart cast 'complex expressions', but it is nonetheless guaranteed*/
         }
         return result?.next
     }


### PR DESCRIPTION
Some variables are unnecessarily nullable. The compiler can't smart cast, but they are nonetheless guaranteed to be non-null.